### PR TITLE
Align colors with CSS variables

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function AboutPage() {
     return (
-        <main className="container mx-auto px-4 py-16 bg-bg text-text-primary">
+        <main className="container mx-auto px-4 py-16 bg-background text-text-primary">
             <AboutMe />
         </main>
     );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -6,7 +6,7 @@ import { motion } from 'framer-motion';
 
 export default function NotFound() {
     return (
-        <section className="min-h-screen flex flex-col items-center justify-center text-center px-6 bg-base-100 text-base-content">
+        <section className="min-h-screen flex flex-col items-center justify-center text-center px-6 bg-background text-foreground">
             <motion.h1
                 initial={{ opacity: 0, y: -20 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -20,7 +20,7 @@ export default function NotFound() {
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 transition={{ delay: 0.3, duration: 0.5 }}
-                className="text-lg text-base-content/80 mb-6 max-w-md"
+                className="text-lg text-foreground-muted mb-6 max-w-md"
             >
                 Oops! The page you&apos;re looking for doesn&apos;t exist, has been moved, or likely Ryan has not created it yet.
             </motion.p>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -23,7 +23,7 @@ export default function Projects() {
             );
 
     return (
-        <section id="projects" className="py-20 px-4 bg-base-100 text-base-content">
+        <section id="projects" className="py-20 px-4 bg-background text-foreground">
             <h2 className="text-3xl font-bold text-center mb-8">Projects Showcase</h2>
 
             {/* Filter Bar */}
@@ -34,7 +34,7 @@ export default function Projects() {
                         onClick={() => setActive(cat)}
                         className={`px-4 py-2 rounded-full text-sm font-semibold transition-colors ${normalize(active) === normalize(cat)
                             ? "bg-primary text-white"
-                            : "bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-700"
+                            : "bg-card text-foreground-muted hover:bg-[hsl(var(--card-hover))]"
                             }`}
                     >
                         {cat.toUpperCase()}

--- a/src/components/CodeSnippetAccordion.tsx
+++ b/src/components/CodeSnippetAccordion.tsx
@@ -45,18 +45,18 @@ export default function CodeSnippetAccordion({
                 <Code className="w-5 h-5" /> {title}
             </h2>
             {snippets.map((snippet, i) => (
-                <div key={i} className="border border-base-300 rounded-lg">
+                <div key={i} className="border border-foreground-muted/20 rounded-lg">
                     <button
                         type="button"
-                        className="w-full text-left px-4 py-3 bg-base-200 hover:bg-base-300 transition-colors font-medium"
+                        className="w-full text-left px-4 py-3 bg-surface hover:bg-[hsl(var(--card-hover))] transition-colors font-medium"
                         onClick={() => setOpenIndex(openIndex === i ? null : i)}
                     >
                         {snippet.title}
                     </button>
                     {openIndex === i && (
-                        <div className="p-4 bg-base-100">
+                        <div className="p-4 bg-card">
                             {snippet.description && (
-                                <p className="mb-2 text-sm text-base-content/70">{snippet.description}</p>
+                                <p className="mb-2 text-sm text-foreground-muted">{snippet.description}</p>
                             )}
                             <SyntaxHighlighter
                                 language={snippet.language || "ts"}

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -4,11 +4,11 @@ import { Mail } from "lucide-react";
 
 export default function ContactSection() {
   return (
-    <section id="contact" className="py-20 px-4 text-center bg-base-100">
+    <section id="contact" className="py-20 px-4 text-center bg-background">
       <h2 className="text-3xl font-bold flex items-center justify-center gap-2 mb-4">
         <Mail /> Contact
       </h2>
-      <p className="max-w-md mx-auto text-base-content/80 mb-6">
+      <p className="max-w-md mx-auto text-foreground-muted mb-6">
         Interested in collaborating? Reach out and let&apos;s build something
         great.
       </p>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,12 +3,12 @@
 
 export default function Footer() {
     return (
-        <footer className="mt-20 border-t border-base-300 bg-base-100 text-base-content py-8 text-sm">
+        <footer className="mt-20 border-t border-foreground-muted/20 bg-background text-foreground py-8 text-sm">
             <div className="container mx-auto px-4 text-center space-y-2">
-                <p className="text-base-content/80">
+                <p className="text-foreground-muted">
                     Built with Next.js, Tailwind CSS, and Love 💖
                 </p>
-                <p className="text-base-content/60">
+                <p className="text-foreground-muted/60">
                     © {new Date().getFullYear()} Ryan Wilson. All rights reserved.
                 </p>
             </div>

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -25,7 +25,7 @@ export default function ProjectCard({
       <motion.article
         whileHover={{ y: -4, scale: 1.02 }}
         transition={{ type: "spring", stiffness: 260, damping: 20 }}
-        className="card bg-base-100 shadow-sm hover:shadow-lg transition"
+        className="card bg-card shadow-sm hover:shadow-lg transition"
         aria-labelledby={`project-${slug}`}
       >
         <div className="card-body">
@@ -34,7 +34,7 @@ export default function ProjectCard({
             <ArrowUpRight className="h-4 w-4 opacity-60 group-hover:opacity-100" />
           </h3>
 
-          <p className="text-base text-base-content/80 leading-relaxed mb-4">
+          <p className="text-base text-foreground-muted leading-relaxed mb-4">
             {description}
           </p>
           <SkillsCloud skills={skillProps} showSearch={false} />

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -19,7 +19,7 @@ export default function Projects() {
             : allProjects.filter((p) => normalize(p.category) === normalize(active));
 
     return (
-        <section id="projects" className="py-20 px-4 bg-base-100 text-base-content">
+        <section id="projects" className="py-20 px-4 bg-background text-foreground">
             <h2 className="text-3xl font-bold text-center mb-8">Projects Showcase</h2>
 
             {/* Filter Bar */}
@@ -29,8 +29,8 @@ export default function Projects() {
                         key={cat}
                         onClick={() => setActive(cat)}
                         className={`px-4 py-2 rounded-full text-sm font-semibold transition-colors ${normalize(active) === normalize(cat)
-                                ? "bg-primary text-white"
-                                : "bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-700"
+                            ? "bg-primary text-white"
+                                : "bg-card text-foreground-muted hover:bg-[hsl(var(--card-hover))]"
                             }`}
                     >
                         {cat.toUpperCase()}

--- a/src/components/ReadmeDrawer.tsx
+++ b/src/components/ReadmeDrawer.tsx
@@ -69,7 +69,7 @@ export default function ReadmeDrawer({ githubUrl }: ReadmeDrawerProps) {
             </button>
 
             {isOpen && (
-                <div className="collapse collapse-open border border-base-300 bg-base-100 rounded-box p-4">
+                <div className="collapse collapse-open border border-foreground-muted/20 bg-card rounded-box p-4">
                     {loading ? (
                         <div className="flex justify-center items-center h-24">
                             <span className="loading loading-bars loading-md"></span>
@@ -133,14 +133,14 @@ export default function ReadmeDrawer({ githubUrl }: ReadmeDrawerProps) {
                                         ) =>
                                             inline ? (
                                                 <code
-                                                    className={`bg-gray-100 dark:bg-gray-800 px-1 rounded break-all ${className}`}
+                                                    className={`bg-surface px-1 rounded break-all ${className}`}
                                                     {...props}
                                                 >
                                                     {children}
                                                 </code>
                                             ) : (
                                                 <pre
-                                                    className="w-full overflow-x-auto bg-gray-200 dark:bg-gray-900 rounded p-2 mb-4"
+                                                    className="w-full overflow-x-auto bg-surface rounded p-2 mb-4"
                                                     {...props}
                                                 >
                                                     <code>{children}</code>

--- a/src/components/ToolsList.tsx
+++ b/src/components/ToolsList.tsx
@@ -1,20 +1,6 @@
 'use client';
 
-const badgeColors: Record<string, string> = {
-    "Next.js": "bg-neutral-900 text-white",
-    TypeScript: "bg-blue-600 text-white",
-    OpenAI: "bg-emerald-500 text-white",
-    Supabase: "bg-green-600 text-white",
-    Shopify: "bg-amber-500 text-black",
-    DaisyUI: "bg-purple-500 text-white",
-    "Tailwind CSS": "bg-sky-500 text-white",
-    "Lucide React": "bg-amber-600 text-white",
-    "Chart.js": "bg-rose-500 text-white",
-    "Framer Motion": "bg-pink-500 text-white",
-};
-
-const getBadgeColor = (tool: string) =>
-    badgeColors[tool] || "bg-gray-400 text-white";
+import { getBadgeColor } from "@/utils/getBadgeColor";
 
 type ToolsListProps = {
     tools: string[];

--- a/src/utils/getBadgeColor.ts
+++ b/src/utils/getBadgeColor.ts
@@ -40,5 +40,5 @@ export const badgeColors: Record<string, string> = {
     "API Integration": "bg-blue-500 text-white"
   };
   
-  export const getBadgeColor = (tool: string): string =>
-    badgeColors[tool] || "bg-base-300 text-base-content";
+export const getBadgeColor = (tool: string): string =>
+    badgeColors[tool] || "bg-card text-foreground";

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,10 +12,13 @@ export default {
     extend: {
       colors: {
         background: "hsl(var(--bg) / <alpha-value>)",
+        surface: "hsl(var(--surface) / <alpha-value>)",
         foreground: "hsl(var(--foreground) / <alpha-value>)",
+        "foreground-muted": "hsl(var(--foreground-muted) / <alpha-value>)",
         primary: "hsl(var(--primary) / <alpha-value>)",
         secondary: "hsl(var(--secondary) / <alpha-value>)",
         accent: "hsl(var(--accent) / <alpha-value>)",
+        card: "hsl(var(--card-bg) / <alpha-value>)",
         "text-primary": "hsl(var(--text-primary) / <alpha-value>)",
         "text-muted": "hsl(var(--text-muted) / <alpha-value>)",
       },

--- a/tests/getBadgeColor.test.ts
+++ b/tests/getBadgeColor.test.ts
@@ -7,6 +7,6 @@ describe('getBadgeColor', () => {
   });
 
   it('returns default color for unknown tool', () => {
-    expect(getBadgeColor('Unknown Tool')).toBe('bg-base-300 text-base-content');
+    expect(getBadgeColor('Unknown Tool')).toBe('bg-card text-foreground');
   });
 });


### PR DESCRIPTION
## Summary
- extend Tailwind palette with `surface`, `card` and muted colors
- apply the palette across pages and components
- update utility and tests for new default badge colors

## Testing
- `npx next lint`
- `npm test`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68434addffc0832abab76d8e0abb1f8c