### PR TITLE
Add manifest and metadata for PWA

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 // jest.config.ts
-import nextJest from 'next/jest';
+const nextJest = require('next/jest');
 
 const createJestConfig = nextJest({
   dir: './',
@@ -13,4 +13,4 @@ const customJestConfig = {
   },
 };
 
-export default createJestConfig(customJestConfig);
+module.exports = createJestConfig(customJestConfig);

--- a/public/favicon/manifest.json
+++ b/public/favicon/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Ryan Wilson Portfolio",
+  "short_name": "Ryan",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/favicon/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/favicon/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from "next-themes";
 import { Inter, Roboto } from "next/font/google";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
+import type { Metadata } from "next";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -25,9 +26,25 @@ const robotoAccent = Roboto({
   display: "swap",
 });
 
-export const metadata = {
+export const metadata: Metadata = {
   title: "Ryan Wilson – Portfolio",
   description: "Full-stack web developer and creative builder.",
+  manifest: "/favicon/manifest.json",
+  themeColor: "#ffffff",
+  icons: {
+    icon: [
+      { url: "/favicon/favicon-32x32.png", sizes: "32x32", type: "image/png" },
+      { url: "/favicon/favicon-16x16.png", sizes: "16x16", type: "image/png" },
+    ],
+    apple: "/favicon/apple-touch-icon.png",
+    other: [{ rel: "shortcut icon", url: "/favicon/favicon.ico" }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Ryan Wilson – Portfolio",
+    description: "Full-stack web developer and creative builder.",
+    images: ["/favicon/opengraph-image.png"],
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- provide manifest.json with PWA fields
- expose favicon, manifest and twitter card metadata in the root layout
- fix Jest config to run in CommonJS mode

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68444c527c0c832a9c0fea1fd08c313e