### PR TITLE
Fix lighthouse badge paths

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -20,7 +20,7 @@ jobs:
         with: { node-version: 20 }
 
       # ③  (Optional) install deps -- keeps lockfile fresh for dependabot
-      - run: pnpm install --frozen-lockfile
+      - run: npm ci
 
       # ④  Run Lighthouse and upload JSON/HTML reports
       - name: Audit production site

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ A modern portfolio built with **Next.js 15**, **TypeScript**, and **Tailwind CSS
 
 ### Lighthouse scores (automated)
 
-![Perf](public/badges/lighthouse-performance.svg)
-![Accessibility](public/badges/lighthouse-accessibility.svg)
-![Best Practices](public/badges/lighthouse-best-practices.svg)
-![SEO](public/badges/lighthouse-seo.svg)
+![Perf](public/badges/lighthouse_performance.svg)
+![Accessibility](public/badges/lighthouse_accessibility.svg)
+![Best Practices](public/badges/lighthouse_best-practices.svg)
+![SEO](public/badges/lighthouse_seo.svg)
 
 
 ## 🛠️ Tech Stack


### PR DESCRIPTION
## Summary
- fix README links to use underscores
- add gitkeep for badges folder
- use npm ci in the lighthouse workflow

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68447667b134832ab34e83b050391d3f